### PR TITLE
Fixed kernel linker issue under buildutil>2.3.3

### DIFF
--- a/kernel.ld
+++ b/kernel.ld
@@ -26,7 +26,7 @@ SECTIONS
 		PROVIDE(__STAB_BEGIN__ = .);
 		*(.stab);
 		PROVIDE(__STAB_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
+		/*BYTE(0)		/* Force the linker to allocate space
 				   for this section */
 	}
 
@@ -34,7 +34,7 @@ SECTIONS
 		PROVIDE(__STABSTR_BEGIN__ = .);
 		*(.stabstr);
 		PROVIDE(__STABSTR_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
+		/*BYTE(0)		/* Force the linker to allocate space
 				   for this section */
 	}
 


### PR DESCRIPTION
    * Origin discussion: https://github.com/mit-pdos/xv6-public/pull/115
    * Credit to @jlei23 